### PR TITLE
feat: Adding Drivers of Change model/API/Admin.

### DIFF
--- a/app/admin/drivers_of_changes.rb
+++ b/app/admin/drivers_of_changes.rb
@@ -1,0 +1,38 @@
+ActiveAdmin.register DriversOfChange do
+  menu parent: "Widgets"
+
+  active_admin_import({
+    before_import: ->(importer) {
+      DriversOfChange.delete_all
+    }
+  })
+
+  permit_params :variable, :value, :primary_driver, :location_id
+
+  form do |f|
+    f.inputs "Details" do
+      f.input :variable, as: :select, collection: DriversOfChange.variables
+      f.input :primary_driver, as: :select, collection: DriversOfChange.primary_drivers
+      f.input :value
+    end
+
+    f.inputs "Location" do
+      f.input :location, as: :select
+    end
+
+    actions
+  end
+
+  csv do
+    column :variable
+    column :primary_driver
+    column :value
+    column :location_id
+  end
+
+  controller do
+    def csv_filename
+      "drivers_of_changes.csv"
+    end
+  end
+end

--- a/app/controllers/v2/widgets_controller.rb
+++ b/app/controllers/v2/widgets_controller.rb
@@ -316,7 +316,7 @@ class V2::WidgetsController < ApiController
       @data = DriversOfChange.includes(:location).where location_id: @location_id
     else
       @location_id = "worldwide"
-      @data = []
+      @data = DriversOfChange.joins(:location).where location: {location_id: @location_id}
     end
   end
 end

--- a/app/controllers/v2/widgets_controller.rb
+++ b/app/controllers/v2/widgets_controller.rb
@@ -308,4 +308,15 @@ class V2::WidgetsController < ApiController
 
     @data = HabitatExtent.select("sum(value - value_prior) as value, ABS(sum(value - value_prior)) as abs_value, name,'net_change' indicator, iso").from(subquery).group(:name, :indicator, :iso).order("2 desc").limit(@limit)
   end
+
+  # GET /v2/widgets/drivers_of_change
+  def drivers_of_change
+    if params.has_key?(:location_id) && params[:location_id] != "worldwide"
+      @location_id = params[:location_id]
+      @data = DriversOfChange.includes(:location).where location_id: @location_id
+    else
+      @location_id = "worldwide"
+      @data = []
+    end
+  end
 end

--- a/app/models/drivers_of_change.rb
+++ b/app/models/drivers_of_change.rb
@@ -1,0 +1,20 @@
+class DriversOfChange < ApplicationRecord
+  belongs_to :location
+
+  enum :variable, {
+    erosion_pct: "erosion_pct",
+    episodic_disturbances_pct: "episodic_disturbances_pct",
+    commodities_pct: "commodities_pct",
+    npc_pct: "npc_pct",
+    settlement_pct: "settlement_pct"
+  }, prefix: true
+  enum :primary_driver, {
+    "NPC" => "NPC",
+    "Episodic Disturbances" => "Episodic Disturbances",
+    "Erosion" => "Erosion",
+    "Settlement" => "Settlement",
+    "Commodities" => "Commodities"
+  }, prefix: true
+
+  validates_presence_of :variable, :value, :primary_driver
+end

--- a/app/views/v2/widgets/drivers_of_change.json.jbuilder
+++ b/app/views/v2/widgets/drivers_of_change.json.jbuilder
@@ -1,0 +1,14 @@
+json.data do
+  json.array! @data do |data|
+    json.variable data.variable
+    json.primary_driver data.primary_driver
+    json.value data.value
+  end
+end
+
+json.metadata do
+  json.location_id @location_id
+  json.units do
+    json.value "%"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
       get "/widgets/blue_carbon", to: "widgets#blue_carbon"
       get "/widgets/mitigation_potentials", to: "widgets#mitigation_potencials"
       get "/widgets/country_ranking", to: "widgets#country_ranking"
+      get "/widgets/drivers_of_change", to: "widgets#drivers_of_change"
 
       ## Geometry file conversion
       post "/spatial_file/converter", to: "file_converter#convert"

--- a/db/migrate/20230511080152_create_drivers_of_changes.rb
+++ b/db/migrate/20230511080152_create_drivers_of_changes.rb
@@ -1,0 +1,12 @@
+class CreateDriversOfChanges < ActiveRecord::Migration[7.0]
+  def change
+    create_table :drivers_of_changes do |t|
+      t.references :location, null: false, foreign_key: true
+      t.string :variable, null: false
+      t.float :value, null: false
+      t.string :primary_driver, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_14_162027) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_11_080152) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -80,6 +80,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_14_162027) do
     t.text "main_loss_driver"
     t.string "indicator", null: false
     t.index ["location_id"], name: "index_degradation_treemaps_on_location_id"
+  end
+
+  create_table "drivers_of_changes", force: :cascade do |t|
+    t.bigint "location_id", null: false
+    t.string "variable", null: false
+    t.float "value", null: false
+    t.string "primary_driver", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_drivers_of_changes_on_location_id"
   end
 
   create_table "ecosystem_services", force: :cascade do |t|
@@ -316,6 +326,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_14_162027) do
   add_foreign_key "blue_carbon_investments", "locations"
   add_foreign_key "blue_carbons", "locations"
   add_foreign_key "degradation_treemaps", "locations"
+  add_foreign_key "drivers_of_changes", "locations"
   add_foreign_key "ecosystem_services", "locations"
   add_foreign_key "habitat_extents", "locations"
   add_foreign_key "international_statuses", "locations"

--- a/spec/factories/drivers_of_changes.rb
+++ b/spec/factories/drivers_of_changes.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :drivers_of_change do
+    location
+    sequence(:variable) do |n|
+      DriversOfChange.variables.keys.sample random: Random.new(n)
+    end
+    sequence(:value) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Number.decimal
+    end
+    sequence(:primary_driver) do |n|
+      DriversOfChange.primary_drivers.keys.sample random: Random.new(n)
+    end
+  end
+end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -30,6 +30,7 @@ FactoryBot.define do
   end
 
   trait :worldwide do
+    location_id { "worldwide" }
     location_type { "worldwide" }
   end
 end

--- a/spec/fixtures/snapshots/api/v2/widgets/drivers_of_change_get_location.json
+++ b/spec/fixtures/snapshots/api/v2/widgets/drivers_of_change_get_location.json
@@ -1,0 +1,15 @@
+{
+  "data": [
+    {
+      "variable": "npc_pct",
+      "primary_driver": "Settlement",
+      "value": 68950.02
+    }
+  ],
+  "metadata": {
+    "location_id": "598",
+    "units": {
+      "value": "%"
+    }
+  }
+}

--- a/spec/fixtures/snapshots/api/v2/widgets/drivers_of_change_get_worldwide.json
+++ b/spec/fixtures/snapshots/api/v2/widgets/drivers_of_change_get_worldwide.json
@@ -1,0 +1,11 @@
+{
+  "data": [
+
+  ],
+  "metadata": {
+    "location_id": "worldwide",
+    "units": {
+      "value": "%"
+    }
+  }
+}

--- a/spec/fixtures/snapshots/api/v2/widgets/drivers_of_change_get_worldwide.json
+++ b/spec/fixtures/snapshots/api/v2/widgets/drivers_of_change_get_worldwide.json
@@ -1,6 +1,10 @@
 {
   "data": [
-
+    {
+      "variable": "erosion_pct",
+      "primary_driver": "NPC",
+      "value": 98628.73
+    }
   ],
   "metadata": {
     "location_id": "worldwide",

--- a/spec/models/drivers_of_change_spec.rb
+++ b/spec/models/drivers_of_change_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe DriversOfChange, type: :model do
+  it { should validate_presence_of(:value) }
+  it { should validate_presence_of(:variable) }
+  it { should validate_presence_of(:primary_driver) }
+end

--- a/spec/requests/api/v2/widgets_spec.rb
+++ b/spec/requests/api/v2/widgets_spec.rb
@@ -862,8 +862,9 @@ RSpec.describe "API V2 Widgets", type: :request do
       parameter name: :location_id, in: :query, type: :string, description: "Location id. Default: worldwide", required: false
 
       let(:location) { create :location }
+      let(:worldwide) { create :location, :worldwide }
       let!(:drivers_of_change_1) { create :drivers_of_change, location: location }
-      let!(:drivers_of_change_2) { create :drivers_of_change }
+      let!(:drivers_of_change_2) { create :drivers_of_change, location: worldwide }
 
       response 200, "Success" do
         schema type: :object,
@@ -900,7 +901,7 @@ RSpec.describe "API V2 Widgets", type: :request do
           end
 
           it "returns correct data" do
-            expect(response_json["data"].pluck("value")).to be_empty
+            expect(response_json["data"].pluck("value")).to eq([drivers_of_change_2.value])
           end
         end
       end

--- a/spec/requests/api/v2/widgets_spec.rb
+++ b/spec/requests/api/v2/widgets_spec.rb
@@ -853,4 +853,57 @@ RSpec.describe "API V2 Widgets", type: :request do
       end
     end
   end
+
+  path "/api/v2/widgets/drivers_of_change" do
+    get "Retrieves the data for the drivers of change widget" do
+      tags "Widgets"
+      consumes "application/json"
+      produces "application/json"
+      parameter name: :location_id, in: :query, type: :string, description: "Location id. Default: worldwide", required: false
+
+      let(:location) { create :location }
+      let!(:drivers_of_change_1) { create :drivers_of_change, location: location }
+      let!(:drivers_of_change_2) { create :drivers_of_change }
+
+      response 200, "Success" do
+        schema type: :object,
+          properties: {
+            data: {
+              type: :array,
+              items: {"$ref" => "#/components/schemas/drivers_of_change"}
+            },
+            metadata: {
+              :type => :object,
+              "$ref" => "#/components/schemas/metadata"
+            }
+          }
+
+        context "when location_id is used" do
+          let(:location_id) { location.id }
+
+          run_test!
+
+          it "matches snapshot", generate_swagger_example: true do
+            expect(response.body).to match_snapshot("api/v2/widgets/drivers_of_change_get_location")
+          end
+
+          it "returns correct data" do
+            expect(response_json["data"].pluck("value")).to eq([drivers_of_change_1.value])
+          end
+        end
+
+        context "when location_id is missing - use worldwide" do
+          run_test!
+
+          it "matches snapshot" do
+            expect(response.body).to match_snapshot("api/v2/widgets/drivers_of_change_get_worldwide")
+          end
+
+          it "returns correct data" do
+            expect(response_json["data"].pluck("value")).to be_empty
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -275,6 +275,14 @@ RSpec.configure do |config|
             },
             required: [:indicator, :value]
           },
+          drivers_of_change: {
+            type: :object,
+            properties: {
+              variable: {type: :string},
+              value: {type: :number},
+              primary_driver: {type: :string}
+            }
+          },
           file_converter: {
             type: :object,
             properties: {

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -150,8 +150,8 @@
                       "coast_length_m": 98628.73,
                       "perimeter_m": 98628.73,
                       "area_m2": 98628.73,
-                      "id": 16109,
-                      "created_at": "2023-05-09T08:53:21.880Z"
+                      "id": 701,
+                      "created_at": "2023-05-11T08:23:13.174Z"
                     },
                     {
                       "name": "Kinshasa",
@@ -163,8 +163,8 @@
                       "coast_length_m": 68950.02,
                       "perimeter_m": 68950.02,
                       "area_m2": 68950.02,
-                      "id": 16108,
-                      "created_at": "2023-05-09T08:53:21.878Z"
+                      "id": 700,
+                      "created_at": "2023-05-11T08:23:13.173Z"
                     }
                   ]
                 },
@@ -212,7 +212,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": 16115,
+                    "id": 707,
                     "iso": "voluptatem",
                     "bounds": {
                     },
@@ -278,7 +278,7 @@
                       "iucn_url": "http://kutch-spencer.com/moises",
                       "red_list_cat": "vu",
                       "location_ids": [
-                        16119
+                        711
                       ]
                     },
                     {
@@ -348,14 +348,14 @@
                 "example": {
                   "data": [
                     {
-                      "id": 2639,
+                      "id": 57,
                       "year": 2016,
                       "total_area": 68950.02,
                       "protected_area": 68950.02
                     }
                   ],
                   "metadata": {
-                    "location_id": "16124",
+                    "location_id": "716",
                     "units": {
                       "total_area": "ha",
                       "protected_area": "ha"
@@ -446,9 +446,9 @@
                     },
                     "species": [
                       {
-                        "id": 1123,
-                        "created_at": "2023-05-09T08:53:22.135Z",
-                        "updated_at": "2023-05-09T08:53:22.135Z",
+                        "id": 41,
+                        "created_at": "2023-05-11T08:23:13.457Z",
+                        "updated_at": "2023-05-11T08:23:13.457Z",
                         "scientific_name": "voluptatem",
                         "common_name": "voluptatem",
                         "iucn_url": "http://kutch-spencer.com/moises",
@@ -519,7 +519,7 @@
                     "mangrove_area_extent": null
                   },
                   "metadata": {
-                    "location_id": "16150",
+                    "location_id": "742",
                     "year": [
                       2019,
                       2018
@@ -596,7 +596,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "16178",
+                    "location_id": "770",
                     "year": [
                       2019,
                       2018
@@ -678,7 +678,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "16212",
+                    "location_id": "804",
                     "unit": "ha",
                     "note": null
                   }
@@ -733,7 +733,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "16226",
+                    "location_id": "818",
                     "note": null
                   }
                 },
@@ -788,7 +788,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "16234",
+                    "location_id": "826",
                     "unit": "mt CO₂ e",
                     "note": null
                   }
@@ -845,7 +845,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "16249",
+                    "location_id": "841",
                     "units": {
                       "habitat_extent_area": "km2",
                       "linear_coverage": "km"
@@ -917,7 +917,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "16267",
+                    "location_id": "859",
                     "units": {
                       "net_change": "km2"
                     },
@@ -991,7 +991,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "16285",
+                    "location_id": "877",
                     "units": {
                       "value": "tons/ha"
                     },
@@ -1059,7 +1059,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "16301",
+                    "location_id": "893",
                     "units": {
                       "value": "m"
                     },
@@ -1124,7 +1124,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "16313",
+                    "location_id": "905",
                     "units": {
                       "value": "CO2e/ha",
                       "toc": "t CO₂e",
@@ -1191,7 +1191,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "16324",
+                    "location_id": "916",
                     "units": {
                       "value": "tCO2/ha"
                     },
@@ -1286,6 +1286,64 @@
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/country_ranking"
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/metadata"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/widgets/drivers_of_change": {
+      "get": {
+        "summary": "Retrieves the data for the drivers of change widget",
+        "tags": [
+          "Widgets"
+        ],
+        "parameters": [
+          {
+            "name": "location_id",
+            "in": "query",
+            "description": "Location id. Default: worldwide",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "variable": "npc_pct",
+                      "primary_driver": "Settlement",
+                      "value": 68950.02
+                    }
+                  ],
+                  "metadata": {
+                    "location_id": "936",
+                    "units": {
+                      "value": "%"
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/drivers_of_change"
                       }
                     },
                     "metadata": {
@@ -1823,6 +1881,20 @@
           "indicator",
           "value"
         ]
+      },
+      "drivers_of_change": {
+        "type": "object",
+        "properties": {
+          "variable": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          },
+          "primary_driver": {
+            "type": "string"
+          }
+        }
       },
       "file_converter": {
         "type": "object",


### PR DESCRIPTION
I am adding new model which should store information about Drivers of Change. There is new API endpoint which allows to obtain this information -- either it uses `location.id` or in case of worldwide it uses `location.location_id` (I have checked staging and there is `worldwide` location with these properties). There is also new Admin section which allows to manage data for this new model.

https://vizzuality.atlassian.net/browse/GMW-511