### PR TITLE
feat: Adding other indicators to EcosystemService

### DIFF
--- a/app/admin/ecosystem_services.rb
+++ b/app/admin/ecosystem_services.rb
@@ -1,19 +1,4 @@
 ActiveAdmin.register EcosystemService do
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # Uncomment all parameters which should be permitted for assignment
-  #
-  # permit_params :location_id, :indicator, :value
-  #
-  # or
-  #
-  # permit_params do
-  #   permitted = [:location_id, :indicator, :value]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
-  #   permitted
-  # end
-
   menu parent: "Widgets"
 
   active_admin_import({
@@ -26,11 +11,7 @@ ActiveAdmin.register EcosystemService do
 
   form do |f|
     f.inputs "Details" do
-      f.input :indicator, as: :select,
-        collection: ["soc", "abgc"],
-        default: "soc",
-        include_blank: false,
-        required: true
+      f.input :indicator, as: :select, collection: EcosystemService.indicators, include_blank: false
       f.input :value, as: :number, required: true
     end
 
@@ -44,7 +25,7 @@ ActiveAdmin.register EcosystemService do
   csv do
     column :indicator
     column :value
-    column(:location_id) { |ecosystem_services| ecosystem_services.location.id }
+    column :location_id
   end
 
   controller do

--- a/app/controllers/v2/widgets_controller.rb
+++ b/app/controllers/v2/widgets_controller.rb
@@ -130,9 +130,7 @@ class V2::WidgetsController < ApiController
   def ecosystem_service
     if params.has_key?(:location_id) && params[:location_id] != "worldwide"
       @location_id = params[:location_id]
-      @data = EcosystemService.select("indicator, location_id, value, sum(value) over () as total_value").where(
-        location_id: params[:location_id]
-      )
+      @data = EcosystemService.select("indicator, location_id, value").where(location_id: params[:location_id])
     else
       @data = EcosystemService.select("indicator, sum(value) as value").group("indicator")
       @location_id = "worldwide"

--- a/app/models/ecosystem_service.rb
+++ b/app/models/ecosystem_service.rb
@@ -1,3 +1,14 @@
 class EcosystemService < ApplicationRecord
   belongs_to :location
+
+  enum :indicator, {
+    "AGB" => "AGB",
+    "SOC" => "SOC",
+    "fish" => "fish",
+    "shrimps" => "shrimps",
+    "crabs" => "crabs",
+    "clams" => "clams"
+  }, default: "SOC", prefix: true
+
+  validates_presence_of :indicator, :value
 end

--- a/spec/factories/ecosystem_services.rb
+++ b/spec/factories/ecosystem_services.rb
@@ -5,8 +5,7 @@ FactoryBot.define do
       Faker::Number.decimal
     end
     sequence(:indicator) do |n|
-      Faker::Config.random = Random.new(n)
-      Faker::Lorem.word
+      EcosystemService.indicators.keys.sample random: Random.new(n)
     end
     location
   end

--- a/spec/fixtures/snapshots/api/v2/widgets/ecosystem_services_get_location.json
+++ b/spec/fixtures/snapshots/api/v2/widgets/ecosystem_services_get_location.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "indicator": "voluptatem",
+      "indicator": "clams",
       "value": 68950.02
     }
   ],

--- a/spec/fixtures/snapshots/api/v2/widgets/ecosystem_services_get_worldwide.json
+++ b/spec/fixtures/snapshots/api/v2/widgets/ecosystem_services_get_worldwide.json
@@ -1,11 +1,11 @@
 {
   "data": [
     {
-      "indicator": "voluptatem",
+      "indicator": "clams",
       "value": 68950.02
     },
     {
-      "indicator": "cum",
+      "indicator": "AGB",
       "value": 98628.73
     }
   ],

--- a/spec/models/ecosystem_service_spec.rb
+++ b/spec/models/ecosystem_service_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe EcosystemService, type: :model do
+  it { should belong_to(:location) }
+
+  it { should validate_presence_of(:indicator) }
+  it { should validate_presence_of(:value) }
+end


### PR DESCRIPTION
I am adding new indicators for fish, shrimps, crabs and clams to EcosystemService model. I have checked Staging db and current indicators are called `AGB` and `SOC` so I have added them to final enum as well.

https://vizzuality.atlassian.net/browse/GMW-466