### PR TITLE
feat: Ecosystem services data can be filtered by slug param

### DIFF
--- a/app/controllers/v2/widgets_controller.rb
+++ b/app/controllers/v2/widgets_controller.rb
@@ -128,6 +128,7 @@ class V2::WidgetsController < ApiController
 
   # GET /v2/widgets/ecosystem_services
   def ecosystem_service
+    slugs = {"restoration-value" => %w[AGB SOC], "fisheries" => %w[fish shrimp crab bivalve]}
     if params.has_key?(:location_id) && params[:location_id] != "worldwide"
       @location_id = params[:location_id]
       @data = EcosystemService.select("indicator, location_id, value").where(location_id: params[:location_id])
@@ -135,6 +136,7 @@ class V2::WidgetsController < ApiController
       @data = EcosystemService.select("indicator, sum(value) as value").group("indicator")
       @location_id = "worldwide"
     end
+    @data = @data.where indicator: slugs[params[:slug]] if params[:slug].present? && slugs[params[:slug]].present?
   end
 
   # GET /v2/widgets/habitat_extent

--- a/spec/requests/api/v2/widgets_spec.rb
+++ b/spec/requests/api/v2/widgets_spec.rb
@@ -423,6 +423,7 @@ RSpec.describe "API V2 Widgets", type: :request do
       consumes "application/json"
       produces "application/json"
       parameter name: :location_id, in: :query, type: :string, description: "Location id. Default: worldwide", required: false
+      parameter name: :slug, in: :query, type: :string, description: "Slug of the ecosystem service. Default: all", required: false
 
       response 200, "Success" do
         schema type: :object,
@@ -438,8 +439,8 @@ RSpec.describe "API V2 Widgets", type: :request do
           }
 
         let(:location) { create :location }
-        let!(:ecosystem_service_1) { create :ecosystem_service, location: location }
-        let!(:ecosystem_service_2) { create :ecosystem_service }
+        let!(:ecosystem_service_1) { create :ecosystem_service, location: location, indicator: "bivalve" }
+        let!(:ecosystem_service_2) { create :ecosystem_service, indicator: "AGB" }
 
         context "when location_id is used" do
           let(:location_id) { location.id }
@@ -464,6 +465,14 @@ RSpec.describe "API V2 Widgets", type: :request do
 
           it "returns correct data" do
             expect(response_json["data"].pluck("value")).to match_array([ecosystem_service_1.value, ecosystem_service_2.value])
+          end
+
+          context "when filtering by slug" do
+            let(:slug) { "restoration-value" }
+
+            it "returns correct data" do
+              expect(response_json["data"].pluck("value")).to eq([ecosystem_service_2.value])
+            end
           end
         end
       end

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -150,8 +150,8 @@
                       "coast_length_m": 98628.73,
                       "perimeter_m": 98628.73,
                       "area_m2": 98628.73,
-                      "id": 735,
-                      "created_at": "2023-05-17T10:28:05.367Z"
+                      "id": 2375,
+                      "created_at": "2023-05-30T08:56:47.480Z"
                     },
                     {
                       "name": "Kinshasa",
@@ -163,8 +163,8 @@
                       "coast_length_m": 68950.02,
                       "perimeter_m": 68950.02,
                       "area_m2": 68950.02,
-                      "id": 734,
-                      "created_at": "2023-05-17T10:28:05.365Z"
+                      "id": 2374,
+                      "created_at": "2023-05-30T08:56:47.479Z"
                     }
                   ]
                 },
@@ -212,7 +212,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": 741,
+                    "id": 2381,
                     "iso": "voluptatem",
                     "bounds": {
                     },
@@ -278,7 +278,7 @@
                       "iucn_url": "http://kutch-spencer.com/moises",
                       "red_list_cat": "vu",
                       "location_ids": [
-                        745
+                        2385
                       ]
                     },
                     {
@@ -348,14 +348,14 @@
                 "example": {
                   "data": [
                     {
-                      "id": 57,
+                      "id": 183,
                       "year": 2016,
                       "total_area": 68950.02,
                       "protected_area": 68950.02
                     }
                   ],
                   "metadata": {
-                    "location_id": "750",
+                    "location_id": "2390",
                     "units": {
                       "total_area": "ha",
                       "protected_area": "ha"
@@ -446,9 +446,9 @@
                     },
                     "species": [
                       {
-                        "id": 57,
-                        "created_at": "2023-05-17T10:28:05.942Z",
-                        "updated_at": "2023-05-17T10:28:05.942Z",
+                        "id": 127,
+                        "created_at": "2023-05-30T08:56:47.851Z",
+                        "updated_at": "2023-05-30T08:56:47.851Z",
                         "scientific_name": "voluptatem",
                         "common_name": "voluptatem",
                         "iucn_url": "http://kutch-spencer.com/moises",
@@ -519,7 +519,7 @@
                     "mangrove_area_extent": null
                   },
                   "metadata": {
-                    "location_id": "776",
+                    "location_id": "2416",
                     "year": [
                       2019,
                       2018
@@ -596,7 +596,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "804",
+                    "location_id": "2444",
                     "year": [
                       2019,
                       2018
@@ -678,7 +678,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "838",
+                    "location_id": "2478",
                     "unit": "ha",
                     "note": null
                   }
@@ -733,7 +733,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "852",
+                    "location_id": "2492",
                     "note": null
                   }
                 },
@@ -773,6 +773,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "slug",
+            "in": "query",
+            "description": "Slug of the ecosystem service. Default: all",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -788,7 +797,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "860",
+                    "location_id": "2500",
                     "unit": "mt CO₂ e",
                     "note": null
                   }
@@ -845,7 +854,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "875",
+                    "location_id": "2517",
                     "units": {
                       "habitat_extent_area": "km2",
                       "linear_coverage": "km"
@@ -917,7 +926,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "893",
+                    "location_id": "2535",
                     "units": {
                       "net_change": "km2"
                     },
@@ -991,7 +1000,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "911",
+                    "location_id": "2553",
                     "units": {
                       "value": "tons/ha"
                     },
@@ -1059,7 +1068,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "927",
+                    "location_id": "2569",
                     "units": {
                       "value": "m"
                     },
@@ -1124,7 +1133,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "939",
+                    "location_id": "2581",
                     "units": {
                       "value": "CO2e/ha",
                       "toc": "t CO₂e",
@@ -1191,7 +1200,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "950",
+                    "location_id": "2592",
                     "units": {
                       "value": "tCO2/ha"
                     },
@@ -1331,7 +1340,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "970",
+                    "location_id": "2612",
                     "units": {
                       "value": "%"
                     }
@@ -1565,73 +1574,73 @@
                 "example": {
                   "data": [
                     {
-                      "id": 304,
+                      "id": 946,
                       "site_name": "Site 1",
-                      "landscape_id": 304,
+                      "landscape_id": 946,
                       "landscape_name": "Landscape 1",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 305,
+                      "id": 947,
                       "site_name": "Site 2",
-                      "landscape_id": 305,
+                      "landscape_id": 947,
                       "landscape_name": "Landscape 2",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 306,
+                      "id": 948,
                       "site_name": "Site 3",
-                      "landscape_id": 306,
+                      "landscape_id": 948,
                       "landscape_name": "Landscape 3",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 307,
+                      "id": 949,
                       "site_name": "Site 4",
-                      "landscape_id": 307,
+                      "landscape_id": 949,
                       "landscape_name": "Landscape 4",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 308,
+                      "id": 950,
                       "site_name": "Site 5",
-                      "landscape_id": 308,
+                      "landscape_id": 950,
                       "landscape_name": "Landscape 5",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 309,
+                      "id": 951,
                       "site_name": "Site 6",
-                      "landscape_id": 309,
+                      "landscape_id": 951,
                       "landscape_name": "Landscape 6",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 310,
+                      "id": 952,
                       "site_name": "Site 7",
-                      "landscape_id": 310,
+                      "landscape_id": 952,
                       "landscape_name": "Landscape 7",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 311,
+                      "id": 953,
                       "site_name": "Site 8",
-                      "landscape_id": 311,
+                      "landscape_id": 953,
                       "landscape_name": "Landscape 8",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 312,
+                      "id": 954,
                       "site_name": "Site 9",
-                      "landscape_id": 312,
+                      "landscape_id": 954,
                       "landscape_name": "Landscape 9",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"


### PR DESCRIPTION
Based on Maria request from https://vizzuality.atlassian.net/browse/GMW-466, I am adding optional `slug` param to ecosystem_services API endpoint which allows to pre-filter values for specific indicators.