### PR TITLE
feat: National dashboard API endpoint

### DIFF
--- a/app/admin/location_resources.rb
+++ b/app/admin/location_resources.rb
@@ -1,0 +1,38 @@
+ActiveAdmin.register LocationResource do
+  menu parent: "Widgets"
+
+  active_admin_import({
+    before_import: ->(importer) {
+      LocationResource.delete_all
+    }
+  })
+
+  permit_params :name, :description, :link, :location_id
+
+  form do |f|
+    f.inputs "Details" do
+      f.input :name
+      f.input :description
+      f.input :link
+    end
+
+    f.inputs "Location" do
+      f.input :location, as: :select
+    end
+
+    actions
+  end
+
+  csv do
+    column :name
+    column :description
+    column :link
+    column :location_id
+  end
+
+  controller do
+    def csv_filename
+      "location_resources.csv"
+    end
+  end
+end

--- a/app/admin/national_dashboards.rb
+++ b/app/admin/national_dashboards.rb
@@ -7,7 +7,7 @@ ActiveAdmin.register NationalDashboard do
     }
   })
 
-  permit_params :source, :indicator, :year, :value, :layer_link, :download_link, :unit, :location_id
+  permit_params :source, :indicator, :year, :value, :layer_info, :layer_link, :download_link, :unit, :location_id
 
   form do |f|
     f.inputs "Details" do
@@ -16,6 +16,7 @@ ActiveAdmin.register NationalDashboard do
       f.input :value
       f.input :unit, as: :select, collection: NationalDashboard.units
       f.input :year
+      f.input :layer_info
       f.input :layer_link
       f.input :download_link
     end
@@ -33,6 +34,7 @@ ActiveAdmin.register NationalDashboard do
     column :value
     column :unit
     column :year
+    column :layer_info
     column :layer_link
     column :download_link
     column :location_id

--- a/app/admin/national_dashboards.rb
+++ b/app/admin/national_dashboards.rb
@@ -1,0 +1,46 @@
+ActiveAdmin.register NationalDashboard do
+  menu parent: "Widgets"
+
+  active_admin_import({
+    before_import: ->(importer) {
+      NationalDashboard.delete_all
+    }
+  })
+
+  permit_params :source, :indicator, :year, :value, :layer_link, :download_link, :unit, :location_id
+
+  form do |f|
+    f.inputs "Details" do
+      f.input :source
+      f.input :indicator, as: :select, collection: NationalDashboard.indicators
+      f.input :value
+      f.input :unit, as: :select, collection: NationalDashboard.units
+      f.input :year
+      f.input :layer_link
+      f.input :download_link
+    end
+
+    f.inputs "Location" do
+      f.input :location, as: :select
+    end
+
+    actions
+  end
+
+  csv do
+    column :source
+    column :indicator
+    column :value
+    column :unit
+    column :year
+    column :layer_link
+    column :download_link
+    column :location_id
+  end
+
+  controller do
+    def csv_filename
+      "national_dashboards.csv"
+    end
+  end
+end

--- a/app/controllers/v2/widgets_controller.rb
+++ b/app/controllers/v2/widgets_controller.rb
@@ -337,4 +337,10 @@ class V2::WidgetsController < ApiController
     @data = @data.with_registration_intervention_answer "6.2", params[:intervention_type] if params[:intervention_type].present?
     @data = @data.with_registration_intervention_answer "6.4", params[:community_activities] if params[:community_activities].present?
   end
+
+  def national_dashboard
+    @location_id = params[:location_id]
+    @data = NationalDashboard.where location_id: @location_id
+    @location_resources = LocationResource.where location_id: @location_id
+  end
 end

--- a/app/models/location_resource.rb
+++ b/app/models/location_resource.rb
@@ -1,0 +1,5 @@
+class LocationResource < ApplicationRecord
+  belongs_to :location
+
+  validates_presence_of :name
+end

--- a/app/models/national_dashboard.rb
+++ b/app/models/national_dashboard.rb
@@ -1,0 +1,8 @@
+class NationalDashboard < ApplicationRecord
+  belongs_to :location
+
+  enum :indicator, {habitat_extent_area: "habitat_extent_area", floods: "floods"}, prefix: true
+  enum :unit, {km2: "km2", GDP: "GDP"}, prefix: true
+
+  validates_presence_of :indicator, :year, :value, :unit
+end

--- a/app/models/national_dashboard.rb
+++ b/app/models/national_dashboard.rb
@@ -4,5 +4,5 @@ class NationalDashboard < ApplicationRecord
   enum :indicator, {habitat_extent_area: "habitat_extent_area", floods: "floods"}, prefix: true
   enum :unit, {km2: "km2", GDP: "GDP"}, prefix: true
 
-  validates_presence_of :indicator, :year, :value, :unit
+  validates_presence_of :indicator, :source, :year, :value, :unit
 end

--- a/app/views/v2/widgets/national_dashboard.json.jbuilder
+++ b/app/views/v2/widgets/national_dashboard.json.jbuilder
@@ -1,0 +1,25 @@
+json.data do
+  json.array! @data do |data|
+    json.year data.year
+    json.source data.source
+    json.indicator data.indicator
+    json.value data.value
+    json.layer_link data.layer_link
+    json.download_link data.download_link
+    json.unit data.unit
+  end
+end
+
+json.metadata do
+  json.location_id @location_id
+  json.location_resources do
+    json.array! @location_resources do |location_resource|
+      json.name location_resource.name
+      json.description location_resource.description
+      json.link location_resource.link
+    end
+  end
+  json.units @data.group_by(&:indicator).map { |k, v| [k, v.first.unit] }.to_h
+  json.years @data.map(&:year).uniq.sort
+  json.note nil
+end

--- a/app/views/v2/widgets/national_dashboard.json.jbuilder
+++ b/app/views/v2/widgets/national_dashboard.json.jbuilder
@@ -1,25 +1,33 @@
 json.data do
-  json.array! @data do |data|
-    json.year data.year
-    json.source data.source
-    json.indicator data.indicator
-    json.value data.value
-    json.layer_link data.layer_link
-    json.download_link data.download_link
-    json.unit data.unit
+  json.array! @data.group_by(&:indicator) do |indicator, data|
+    json.indicator indicator
+    json.sources do
+      json.array! data.group_by(&:source) do |source, data_source|
+        json.source source
+        json.unit data_source.first&.unit
+        json.years data_source.map(&:year).uniq.sort
+        json.data_source do
+          json.array! data_source do |record|
+            json.year record.year
+            json.value record.value
+            json.layer_info record.layer_info
+            json.layer_link record.layer_link
+            json.download_link record.download_link
+          end
+        end
+      end
+    end
   end
 end
 
 json.metadata do
   json.location_id @location_id
-  json.location_resources do
+  json.other_resources do
     json.array! @location_resources do |location_resource|
       json.name location_resource.name
       json.description location_resource.description
       json.link location_resource.link
     end
   end
-  json.units @data.group_by(&:indicator).map { |k, v| [k, v.first.unit] }.to_h
-  json.years @data.map(&:year).uniq.sort
   json.note nil
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
       get "/widgets/drivers_of_change", to: "widgets#drivers_of_change"
       get "/widgets/sites_filters", to: "widgets#sites_filters"
       get "/widgets/sites", to: "widgets#sites"
+      get "/widgets/national_dashboard", to: "widgets#national_dashboard"
 
       ## Geometry file conversion
       post "/spatial_file/converter", to: "file_converter#convert"

--- a/db/migrate/20230607114018_create_national_dashboards.rb
+++ b/db/migrate/20230607114018_create_national_dashboards.rb
@@ -1,0 +1,16 @@
+class CreateNationalDashboards < ActiveRecord::Migration[7.0]
+  def change
+    create_table :national_dashboards do |t|
+      t.references :location, null: false, foreign_key: true
+      t.string :source
+      t.string :indicator, null: false
+      t.integer :year, null: false
+      t.float :value, null: false
+      t.string :layer_link
+      t.string :download_link
+      t.string :unit, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230607114018_create_national_dashboards.rb
+++ b/db/migrate/20230607114018_create_national_dashboards.rb
@@ -6,6 +6,7 @@ class CreateNationalDashboards < ActiveRecord::Migration[7.0]
       t.string :indicator, null: false
       t.integer :year, null: false
       t.float :value, null: false
+      t.string :layer_info
       t.string :layer_link
       t.string :download_link
       t.string :unit, null: false

--- a/db/migrate/20230607115240_create_location_resources.rb
+++ b/db/migrate/20230607115240_create_location_resources.rb
@@ -1,0 +1,12 @@
+class CreateLocationResources < ActiveRecord::Migration[7.0]
+  def change
+    create_table :location_resources do |t|
+      t.references :location, null: false, foreign_key: true
+      t.string :name, null: false
+      t.text :description
+      t.string :link
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -101,17 +101,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_115240) do
     t.index ["location_id"], name: "index_ecosystem_services_on_location_id"
   end
 
-  create_table "flood_protections", force: :cascade do |t|
-    t.bigint "location_id", null: false
-    t.string "indicator", null: false
-    t.string "period", null: false
-    t.float "value", null: false
-    t.string "unit", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["location_id"], name: "index_flood_protections_on_location_id"
-  end
-
   create_table "habitat_extents", force: :cascade do |t|
     t.bigint "location_id", null: false
     t.enum "indicator", default: "habitat_extent_area", null: false, enum_type: "habitat_extent_indicators"
@@ -364,7 +353,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_115240) do
   add_foreign_key "degradation_treemaps", "locations"
   add_foreign_key "drivers_of_changes", "locations"
   add_foreign_key "ecosystem_services", "locations"
-  add_foreign_key "flood_protections", "locations"
   add_foreign_key "habitat_extents", "locations"
   add_foreign_key "international_statuses", "locations"
   add_foreign_key "landscapes_organizations", "landscapes"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_15_102127) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_07_115240) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -101,6 +101,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_102127) do
     t.index ["location_id"], name: "index_ecosystem_services_on_location_id"
   end
 
+  create_table "flood_protections", force: :cascade do |t|
+    t.bigint "location_id", null: false
+    t.string "indicator", null: false
+    t.string "period", null: false
+    t.float "value", null: false
+    t.string "unit", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_flood_protections_on_location_id"
+  end
+
   create_table "habitat_extents", force: :cascade do |t|
     t.bigint "location_id", null: false
     t.enum "indicator", default: "habitat_extent_area", null: false, enum_type: "habitat_extent_indicators"
@@ -141,6 +152,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_102127) do
     t.index ["landscape_id", "organization_id"], name: "idx_u_landscapes_organizations", unique: true
     t.index ["landscape_id"], name: "index_landscapes_organizations_on_landscape_id"
     t.index ["organization_id"], name: "index_landscapes_organizations_on_organization_id"
+  end
+
+  create_table "location_resources", force: :cascade do |t|
+    t.bigint "location_id", null: false
+    t.string "name", null: false
+    t.text "description"
+    t.string "link"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_location_resources_on_location_id"
   end
 
   create_table "locations", force: :cascade do |t|
@@ -205,6 +226,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_102127) do
     t.string "uuid"
     t.string "form_type"
     t.index ["site_id"], name: "index_monitoring_answers_on_site_id"
+  end
+
+  create_table "national_dashboards", force: :cascade do |t|
+    t.bigint "location_id", null: false
+    t.string "source"
+    t.string "indicator", null: false
+    t.integer "year", null: false
+    t.float "value", null: false
+    t.string "layer_link"
+    t.string "download_link"
+    t.string "unit", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_national_dashboards_on_location_id"
   end
 
   create_table "organizations", force: :cascade do |t|
@@ -328,13 +363,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_102127) do
   add_foreign_key "degradation_treemaps", "locations"
   add_foreign_key "drivers_of_changes", "locations"
   add_foreign_key "ecosystem_services", "locations"
+  add_foreign_key "flood_protections", "locations"
   add_foreign_key "habitat_extents", "locations"
   add_foreign_key "international_statuses", "locations"
   add_foreign_key "landscapes_organizations", "landscapes"
   add_foreign_key "landscapes_organizations", "organizations"
+  add_foreign_key "location_resources", "locations"
   add_foreign_key "mangrove_data", "locations"
   add_foreign_key "mitigation_potentials", "locations"
   add_foreign_key "monitoring_answers", "sites"
+  add_foreign_key "national_dashboards", "locations"
   add_foreign_key "organizations_users", "organizations"
   add_foreign_key "organizations_users", "users"
   add_foreign_key "registration_intervention_answers", "sites"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -234,6 +234,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_115240) do
     t.string "indicator", null: false
     t.integer "year", null: false
     t.float "value", null: false
+    t.string "layer_info"
     t.string "layer_link"
     t.string "download_link"
     t.string "unit", null: false

--- a/spec/factories/location_resources.rb
+++ b/spec/factories/location_resources.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :location_resource do
+    location
+    sequence(:name) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.word
+    end
+    sequence(:description) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.paragraph
+    end
+    sequence(:link) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Internet.url
+    end
+  end
+end

--- a/spec/factories/national_dashboards.rb
+++ b/spec/factories/national_dashboards.rb
@@ -1,0 +1,31 @@
+FactoryBot.define do
+  factory :national_dashboard do
+    location
+    sequence(:source) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.word
+    end
+    sequence(:indicator) do |n|
+      NationalDashboard.indicators.keys.sample random: Random.new(n)
+    end
+    sequence(:year) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Date.between(from: "2014-01-01", to: "2022-01-01").year
+    end
+    sequence(:layer_link) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Internet.url
+    end
+    sequence(:download_link) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Internet.url
+    end
+    sequence(:value) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Number.decimal
+    end
+    sequence(:unit) do |n|
+      NationalDashboard.units.keys.sample random: Random.new(n)
+    end
+  end
+end

--- a/spec/factories/national_dashboards.rb
+++ b/spec/factories/national_dashboards.rb
@@ -12,6 +12,10 @@ FactoryBot.define do
       Faker::Config.random = Random.new(n)
       Faker::Date.between(from: "2014-01-01", to: "2022-01-01").year
     end
+    sequence(:layer_info) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.sentence
+    end
     sequence(:layer_link) do |n|
       Faker::Config.random = Random.new(n)
       Faker::Internet.url

--- a/spec/fixtures/snapshots/api/v2/widgets/national_dashboard.json
+++ b/spec/fixtures/snapshots/api/v2/widgets/national_dashboard.json
@@ -1,0 +1,30 @@
+{
+  "data": [
+    {
+      "year": 2016,
+      "source": "voluptatem",
+      "indicator": "floods",
+      "value": 68950.02,
+      "layer_link": "http://kutch-spencer.com/moises",
+      "download_link": "http://kutch-spencer.com/moises",
+      "unit": "GDP"
+    }
+  ],
+  "metadata": {
+    "location_id": "506",
+    "location_resources": [
+      {
+        "name": "voluptatem",
+        "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem.",
+        "link": "http://kutch-spencer.com/moises"
+      }
+    ],
+    "units": {
+      "floods": "GDP"
+    },
+    "years": [
+      2016
+    ],
+    "note": null
+  }
+}

--- a/spec/fixtures/snapshots/api/v2/widgets/national_dashboard.json
+++ b/spec/fixtures/snapshots/api/v2/widgets/national_dashboard.json
@@ -1,29 +1,35 @@
 {
   "data": [
     {
-      "year": 2016,
-      "source": "voluptatem",
       "indicator": "floods",
-      "value": 68950.02,
-      "layer_link": "http://kutch-spencer.com/moises",
-      "download_link": "http://kutch-spencer.com/moises",
-      "unit": "GDP"
+      "sources": [
+        {
+          "source": "voluptatem",
+          "unit": "GDP",
+          "years": [
+            2016
+          ],
+          "data_source": [
+            {
+              "year": 2016,
+              "value": 68950.02,
+              "layer_info": "Enim repellat pariatur est.",
+              "layer_link": "http://kutch-spencer.com/moises",
+              "download_link": "http://kutch-spencer.com/moises"
+            }
+          ]
+        }
+      ]
     }
   ],
   "metadata": {
-    "location_id": "506",
-    "location_resources": [
+    "location_id": "226",
+    "other_resources": [
       {
         "name": "voluptatem",
         "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem.",
         "link": "http://kutch-spencer.com/moises"
       }
-    ],
-    "units": {
-      "floods": "GDP"
-    },
-    "years": [
-      2016
     ],
     "note": null
   }

--- a/spec/models/location_resource_spec.rb
+++ b/spec/models/location_resource_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe LocationResource, type: :model do
+  it { should validate_presence_of(:name) }
+end

--- a/spec/models/national_dashboard_spec.rb
+++ b/spec/models/national_dashboard_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe NationalDashboard, type: :model do
   it { should validate_presence_of(:indicator) }
+  it { should validate_presence_of(:source) }
   it { should validate_presence_of(:year) }
   it { should validate_presence_of(:value) }
   it { should validate_presence_of(:unit) }

--- a/spec/models/national_dashboard_spec.rb
+++ b/spec/models/national_dashboard_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe NationalDashboard, type: :model do
+  it { should validate_presence_of(:indicator) }
+  it { should validate_presence_of(:year) }
+  it { should validate_presence_of(:value) }
+  it { should validate_presence_of(:unit) }
+end

--- a/spec/requests/api/v2/widgets_spec.rb
+++ b/spec/requests/api/v2/widgets_spec.rb
@@ -1102,4 +1102,44 @@ RSpec.describe "API V2 Widgets", type: :request do
       end
     end
   end
+
+  path "/api/v2/widgets/national_dashboard" do
+    get "Retrieves the data for the national dashboard widget" do
+      tags "Widgets"
+      consumes "application/json"
+      produces "application/json"
+      parameter name: :location_id, in: :query, type: :string, description: "Location id", required: true
+
+      let(:location) { create :location }
+      let!(:national_dashboard_1) { create :national_dashboard, location: location }
+      let!(:national_dashboard_2) { create :national_dashboard }
+      let!(:location_resource) { create :location_resource, location: location }
+
+      let(:location_id) { location.id }
+
+      response 200, "Success" do
+        schema type: :object,
+          properties: {
+            data: {
+              type: :array,
+              items: {"$ref" => "#/components/schemas/national_dashboard"}
+            },
+            metadata: {
+              :type => :object,
+              "$ref" => "#/components/schemas/metadata"
+            }
+          }
+
+        run_test!
+
+        it "matches snapshot", generate_swagger_example: true do
+          expect(response.body).to match_snapshot("api/v2/widgets/national_dashboard")
+        end
+
+        it "returns correct data" do
+          expect(response_json["data"].pluck("value")).to eq([national_dashboard_1.value])
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/v2/widgets_spec.rb
+++ b/spec/requests/api/v2/widgets_spec.rb
@@ -1137,7 +1137,13 @@ RSpec.describe "API V2 Widgets", type: :request do
         end
 
         it "returns correct data" do
-          expect(response_json["data"].pluck("value")).to eq([national_dashboard_1.value])
+          expect(response_json["data"].first["indicator"]).to eq(national_dashboard_1.indicator)
+          expect(response_json["data"].first["sources"].first["source"]).to eq(national_dashboard_1.source)
+          expect(response_json["data"].first["sources"].first["data_source"].pluck("value")).to eq([national_dashboard_1.value])
+        end
+
+        it "returns correct metadata" do
+          expect(response_json["metadata"]["other_resources"].pluck("name")).to eq([location_resource.name])
         end
       end
     end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -52,7 +52,12 @@ RSpec.configure do |config|
                 nullable: true
               },
               note: {type: :string, nullable: true},
-              worldwide_total: {type: :number, nullable: true, description: "total number of species in the world"}
+              worldwide_total: {type: :number, nullable: true, description: "total number of species in the world"},
+              location_resources: {
+                type: :array,
+                items: {"$ref" => "#/components/schemas/location_resource"},
+                nullable: true
+              }
             }
           },
           error_response: {
@@ -284,6 +289,18 @@ RSpec.configure do |config|
               primary_driver: {type: :string}
             }
           },
+          national_dashboard: {
+            type: :object,
+            properties: {
+              year: {type: :number},
+              source: {type: :string, nullable: true},
+              value: {type: :number},
+              indicator: {type: :string},
+              layer_link: {type: :string, nullable: true},
+              download_link: {type: :string, nullable: true},
+              unit: {type: :string}
+            }
+          },
           sites_filters: {
             type: :object,
             properties: {
@@ -317,6 +334,14 @@ RSpec.configure do |config|
               }
             },
             required: [:type, :features]
+          },
+          location_resource: {
+            type: :object,
+            properties: {
+              name: {type: :string},
+              description: {type: :string, nullable: true},
+              link: {type: :string, nullable: true}
+            }
           }
         }
       }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -292,13 +292,31 @@ RSpec.configure do |config|
           national_dashboard: {
             type: :object,
             properties: {
-              year: {type: :number},
-              source: {type: :string, nullable: true},
-              value: {type: :number},
               indicator: {type: :string},
-              layer_link: {type: :string, nullable: true},
-              download_link: {type: :string, nullable: true},
-              unit: {type: :string}
+              sources: {
+                type: :array,
+                items: {
+                  type: :object,
+                  properties: {
+                    source: {type: :string},
+                    unit: {type: :string},
+                    years: {type: :array, items: {type: :number}},
+                    data_source: {
+                      type: :array,
+                      items: {
+                        type: :object,
+                        properties: {
+                          year: {type: :number},
+                          value: {type: :number},
+                          layer_info: {type: :string, nullable: true},
+                          layer_link: {type: :string, nullable: true},
+                          download_link: {type: :string, nullable: true}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           sites_filters: {

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -150,8 +150,8 @@
                       "coast_length_m": 98628.73,
                       "perimeter_m": 98628.73,
                       "area_m2": 98628.73,
-                      "id": 4595,
-                      "created_at": "2023-06-07T11:31:58.147Z"
+                      "id": 1731,
+                      "created_at": "2023-06-07T12:22:07.205Z"
                     },
                     {
                       "name": "Kinshasa",
@@ -163,8 +163,8 @@
                       "coast_length_m": 68950.02,
                       "perimeter_m": 68950.02,
                       "area_m2": 68950.02,
-                      "id": 4594,
-                      "created_at": "2023-06-07T11:31:58.146Z"
+                      "id": 1730,
+                      "created_at": "2023-06-07T12:22:07.204Z"
                     }
                   ]
                 },
@@ -212,7 +212,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": 4601,
+                    "id": 1737,
                     "iso": "voluptatem",
                     "bounds": {
                     },
@@ -278,7 +278,7 @@
                       "iucn_url": "http://kutch-spencer.com/moises",
                       "red_list_cat": "vu",
                       "location_ids": [
-                        4605
+                        1741
                       ]
                     },
                     {
@@ -348,14 +348,14 @@
                 "example": {
                   "data": [
                     {
-                      "id": 345,
+                      "id": 129,
                       "year": 2016,
                       "total_area": 68950.02,
                       "protected_area": 68950.02
                     }
                   ],
                   "metadata": {
-                    "location_id": "4610",
+                    "location_id": "1746",
                     "units": {
                       "total_area": "ha",
                       "protected_area": "ha"
@@ -446,9 +446,9 @@
                     },
                     "species": [
                       {
-                        "id": 267,
-                        "created_at": "2023-06-07T11:31:58.668Z",
-                        "updated_at": "2023-06-07T11:31:58.668Z",
+                        "id": 95,
+                        "created_at": "2023-06-07T12:22:07.658Z",
+                        "updated_at": "2023-06-07T12:22:07.658Z",
                         "scientific_name": "voluptatem",
                         "common_name": "voluptatem",
                         "iucn_url": "http://kutch-spencer.com/moises",
@@ -520,7 +520,7 @@
                     "mangrove_area_extent": null
                   },
                   "metadata": {
-                    "location_id": "4643",
+                    "location_id": "1779",
                     "year": [
                       2019,
                       2018
@@ -597,7 +597,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "4671",
+                    "location_id": "1807",
                     "year": [
                       2019,
                       2018
@@ -679,7 +679,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "4705",
+                    "location_id": "1841",
                     "unit": "ha",
                     "note": null
                   }
@@ -734,7 +734,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "4719",
+                    "location_id": "1855",
                     "note": null
                   }
                 },
@@ -818,7 +818,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "4727",
+                    "location_id": "1863",
                     "unit": "mt CO₂ e",
                     "note": null
                   }
@@ -875,7 +875,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "4744",
+                    "location_id": "1880",
                     "units": {
                       "habitat_extent_area": "km2",
                       "linear_coverage": "km"
@@ -947,7 +947,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "4762",
+                    "location_id": "1898",
                     "units": {
                       "net_change": "km2"
                     },
@@ -1021,7 +1021,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "4780",
+                    "location_id": "1916",
                     "units": {
                       "value": "tons/ha"
                     },
@@ -1089,7 +1089,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "4796",
+                    "location_id": "1932",
                     "units": {
                       "value": "m"
                     },
@@ -1154,7 +1154,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "4808",
+                    "location_id": "1944",
                     "units": {
                       "value": "CO2e/ha",
                       "toc": "t CO₂e",
@@ -1221,7 +1221,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "4819",
+                    "location_id": "1955",
                     "units": {
                       "value": "tCO2/ha"
                     },
@@ -1361,7 +1361,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "4839",
+                    "location_id": "1975",
                     "units": {
                       "value": "%"
                     }
@@ -1595,73 +1595,73 @@
                 "example": {
                   "data": [
                     {
-                      "id": 1828,
+                      "id": 648,
                       "site_name": "Site 1",
-                      "landscape_id": 1828,
+                      "landscape_id": 648,
                       "landscape_name": "Landscape 1",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 1829,
+                      "id": 649,
                       "site_name": "Site 2",
-                      "landscape_id": 1829,
+                      "landscape_id": 649,
                       "landscape_name": "Landscape 2",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 1830,
+                      "id": 650,
                       "site_name": "Site 3",
-                      "landscape_id": 1830,
+                      "landscape_id": 650,
                       "landscape_name": "Landscape 3",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 1831,
+                      "id": 651,
                       "site_name": "Site 4",
-                      "landscape_id": 1831,
+                      "landscape_id": 651,
                       "landscape_name": "Landscape 4",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 1832,
+                      "id": 652,
                       "site_name": "Site 5",
-                      "landscape_id": 1832,
+                      "landscape_id": 652,
                       "landscape_name": "Landscape 5",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 1833,
+                      "id": 653,
                       "site_name": "Site 6",
-                      "landscape_id": 1833,
+                      "landscape_id": 653,
                       "landscape_name": "Landscape 6",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 1834,
+                      "id": 654,
                       "site_name": "Site 7",
-                      "landscape_id": 1834,
+                      "landscape_id": 654,
                       "landscape_name": "Landscape 7",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 1835,
+                      "id": 655,
                       "site_name": "Site 8",
-                      "landscape_id": 1835,
+                      "landscape_id": 655,
                       "landscape_name": "Landscape 8",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 1836,
+                      "id": 656,
                       "site_name": "Site 9",
-                      "landscape_id": 1836,
+                      "landscape_id": 656,
                       "landscape_name": "Landscape 9",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
@@ -1676,6 +1676,79 @@
                       "items": {
                         "$ref": "#/components/schemas/sites"
                       }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/widgets/national_dashboard": {
+      "get": {
+        "summary": "Retrieves the data for the national dashboard widget",
+        "tags": [
+          "Widgets"
+        ],
+        "parameters": [
+          {
+            "name": "location_id",
+            "in": "query",
+            "description": "Location id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": [
+                    {
+                      "year": 2016,
+                      "source": "voluptatem",
+                      "indicator": "floods",
+                      "value": 68950.02,
+                      "layer_link": "http://kutch-spencer.com/moises",
+                      "download_link": "http://kutch-spencer.com/moises",
+                      "unit": "GDP"
+                    }
+                  ],
+                  "metadata": {
+                    "location_id": "1987",
+                    "location_resources": [
+                      {
+                        "name": "voluptatem",
+                        "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem.",
+                        "link": "http://kutch-spencer.com/moises"
+                      }
+                    ],
+                    "units": {
+                      "floods": "GDP"
+                    },
+                    "years": [
+                      2016
+                    ],
+                    "note": null
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/national_dashboard"
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/metadata"
                     }
                   }
                 }
@@ -1728,6 +1801,13 @@
             "type": "number",
             "nullable": true,
             "description": "total number of species in the world"
+          },
+          "location_resources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/location_resource"
+            },
+            "nullable": true
           }
         }
       },
@@ -2229,6 +2309,35 @@
           }
         }
       },
+      "national_dashboard": {
+        "type": "object",
+        "properties": {
+          "year": {
+            "type": "number"
+          },
+          "source": {
+            "type": "string",
+            "nullable": true
+          },
+          "value": {
+            "type": "number"
+          },
+          "indicator": {
+            "type": "string"
+          },
+          "layer_link": {
+            "type": "string",
+            "nullable": true
+          },
+          "download_link": {
+            "type": "string",
+            "nullable": true
+          },
+          "unit": {
+            "type": "string"
+          }
+        }
+      },
       "sites_filters": {
         "type": "object",
         "properties": {
@@ -2311,6 +2420,22 @@
           "type",
           "features"
         ]
+      },
+      "location_resource": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "link": {
+            "type": "string",
+            "nullable": true
+          }
+        }
       }
     }
   }

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -150,8 +150,8 @@
                       "coast_length_m": 98628.73,
                       "perimeter_m": 98628.73,
                       "area_m2": 98628.73,
-                      "id": 1731,
-                      "created_at": "2023-06-07T12:22:07.205Z"
+                      "id": 750,
+                      "created_at": "2023-06-08T11:55:31.812Z"
                     },
                     {
                       "name": "Kinshasa",
@@ -163,8 +163,8 @@
                       "coast_length_m": 68950.02,
                       "perimeter_m": 68950.02,
                       "area_m2": 68950.02,
-                      "id": 1730,
-                      "created_at": "2023-06-07T12:22:07.204Z"
+                      "id": 749,
+                      "created_at": "2023-06-08T11:55:31.811Z"
                     }
                   ]
                 },
@@ -212,7 +212,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": 1737,
+                    "id": 756,
                     "iso": "voluptatem",
                     "bounds": {
                     },
@@ -278,7 +278,7 @@
                       "iucn_url": "http://kutch-spencer.com/moises",
                       "red_list_cat": "vu",
                       "location_ids": [
-                        1741
+                        760
                       ]
                     },
                     {
@@ -348,14 +348,14 @@
                 "example": {
                   "data": [
                     {
-                      "id": 129,
+                      "id": 57,
                       "year": 2016,
                       "total_area": 68950.02,
                       "protected_area": 68950.02
                     }
                   ],
                   "metadata": {
-                    "location_id": "1746",
+                    "location_id": "765",
                     "units": {
                       "total_area": "ha",
                       "protected_area": "ha"
@@ -446,9 +446,9 @@
                     },
                     "species": [
                       {
-                        "id": 95,
-                        "created_at": "2023-06-07T12:22:07.658Z",
-                        "updated_at": "2023-06-07T12:22:07.658Z",
+                        "id": 47,
+                        "created_at": "2023-06-08T11:55:32.217Z",
+                        "updated_at": "2023-06-08T11:55:32.217Z",
                         "scientific_name": "voluptatem",
                         "common_name": "voluptatem",
                         "iucn_url": "http://kutch-spencer.com/moises",
@@ -520,7 +520,7 @@
                     "mangrove_area_extent": null
                   },
                   "metadata": {
-                    "location_id": "1779",
+                    "location_id": "798",
                     "year": [
                       2019,
                       2018
@@ -597,7 +597,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "1807",
+                    "location_id": "826",
                     "year": [
                       2019,
                       2018
@@ -679,7 +679,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "1841",
+                    "location_id": "860",
                     "unit": "ha",
                     "note": null
                   }
@@ -734,7 +734,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "1855",
+                    "location_id": "874",
                     "note": null
                   }
                 },
@@ -818,7 +818,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "1863",
+                    "location_id": "882",
                     "unit": "mt CO₂ e",
                     "note": null
                   }
@@ -875,7 +875,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "1880",
+                    "location_id": "899",
                     "units": {
                       "habitat_extent_area": "km2",
                       "linear_coverage": "km"
@@ -947,7 +947,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "1898",
+                    "location_id": "917",
                     "units": {
                       "net_change": "km2"
                     },
@@ -1021,7 +1021,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "1916",
+                    "location_id": "935",
                     "units": {
                       "value": "tons/ha"
                     },
@@ -1089,7 +1089,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "1932",
+                    "location_id": "951",
                     "units": {
                       "value": "m"
                     },
@@ -1154,7 +1154,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "1944",
+                    "location_id": "963",
                     "units": {
                       "value": "CO2e/ha",
                       "toc": "t CO₂e",
@@ -1221,7 +1221,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "1955",
+                    "location_id": "974",
                     "units": {
                       "value": "tCO2/ha"
                     },
@@ -1361,7 +1361,7 @@
                     }
                   ],
                   "metadata": {
-                    "location_id": "1975",
+                    "location_id": "994",
                     "units": {
                       "value": "%"
                     }
@@ -1595,73 +1595,73 @@
                 "example": {
                   "data": [
                     {
-                      "id": 648,
+                      "id": 288,
                       "site_name": "Site 1",
-                      "landscape_id": 648,
+                      "landscape_id": 288,
                       "landscape_name": "Landscape 1",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 649,
+                      "id": 289,
                       "site_name": "Site 2",
-                      "landscape_id": 649,
+                      "landscape_id": 289,
                       "landscape_name": "Landscape 2",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 650,
+                      "id": 290,
                       "site_name": "Site 3",
-                      "landscape_id": 650,
+                      "landscape_id": 290,
                       "landscape_name": "Landscape 3",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 651,
+                      "id": 291,
                       "site_name": "Site 4",
-                      "landscape_id": 651,
+                      "landscape_id": 291,
                       "landscape_name": "Landscape 4",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 652,
+                      "id": 292,
                       "site_name": "Site 5",
-                      "landscape_id": 652,
+                      "landscape_id": 292,
                       "landscape_name": "Landscape 5",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 653,
+                      "id": 293,
                       "site_name": "Site 6",
-                      "landscape_id": 653,
+                      "landscape_id": 293,
                       "landscape_name": "Landscape 6",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 654,
+                      "id": 294,
                       "site_name": "Site 7",
-                      "landscape_id": 654,
+                      "landscape_id": 294,
                       "landscape_name": "Landscape 7",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 655,
+                      "id": 295,
                       "site_name": "Site 8",
-                      "landscape_id": 655,
+                      "landscape_id": 295,
                       "landscape_name": "Landscape 8",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
                     },
                     {
-                      "id": 656,
+                      "id": 296,
                       "site_name": "Site 9",
-                      "landscape_id": 656,
+                      "landscape_id": 296,
                       "landscape_name": "Landscape 9",
                       "site_area": "{\"type\":\"Polygon\",\"coordinates\":[[[-16.609301736,12.603397456],[-16.613187506,12.600979269],[-16.612117512,12.597983983],[-16.609921206,12.5985061],[-16.608851212,12.600374719],[-16.609301736,12.603397456]]]}",
                       "site_centroid": "{\"type\":\"Point\",\"coordinates\":[-16.610831584,12.60048394]}"
@@ -1710,29 +1710,35 @@
                 "example": {
                   "data": [
                     {
-                      "year": 2016,
-                      "source": "voluptatem",
                       "indicator": "floods",
-                      "value": 68950.02,
-                      "layer_link": "http://kutch-spencer.com/moises",
-                      "download_link": "http://kutch-spencer.com/moises",
-                      "unit": "GDP"
+                      "sources": [
+                        {
+                          "source": "voluptatem",
+                          "unit": "GDP",
+                          "years": [
+                            2016
+                          ],
+                          "data_source": [
+                            {
+                              "year": 2016,
+                              "value": 68950.02,
+                              "layer_info": "Enim repellat pariatur est.",
+                              "layer_link": "http://kutch-spencer.com/moises",
+                              "download_link": "http://kutch-spencer.com/moises"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ],
                   "metadata": {
-                    "location_id": "1987",
-                    "location_resources": [
+                    "location_id": "1006",
+                    "other_resources": [
                       {
                         "name": "voluptatem",
                         "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem.",
                         "link": "http://kutch-spencer.com/moises"
                       }
-                    ],
-                    "units": {
-                      "floods": "GDP"
-                    },
-                    "years": [
-                      2016
                     ],
                     "note": null
                   }
@@ -2312,29 +2318,54 @@
       "national_dashboard": {
         "type": "object",
         "properties": {
-          "year": {
-            "type": "number"
-          },
-          "source": {
-            "type": "string",
-            "nullable": true
-          },
-          "value": {
-            "type": "number"
-          },
           "indicator": {
             "type": "string"
           },
-          "layer_link": {
-            "type": "string",
-            "nullable": true
-          },
-          "download_link": {
-            "type": "string",
-            "nullable": true
-          },
-          "unit": {
-            "type": "string"
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string"
+                },
+                "unit": {
+                  "type": "string"
+                },
+                "years": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  }
+                },
+                "data_source": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "year": {
+                        "type": "number"
+                      },
+                      "value": {
+                        "type": "number"
+                      },
+                      "layer_info": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "layer_link": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "download_link": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
Adding all BE stuff required for National dashboard:
 - two new models called `NationalDashboard` and `LocationResource`
 - two new administrations for models mentioned above
 - one API endpoint at `widgets/national_dashboard` which combines information from models mentioned above --> data from `LocationResource` model is put under `location_resources` field at `metadata` section

https://vizzuality.atlassian.net/browse/GMW-576