### PR TITLE
fix incorrect assignment of public_only

### DIFF
--- a/app/controllers/v2/report_controller.rb
+++ b/app/controllers/v2/report_controller.rb
@@ -62,7 +62,11 @@ class V2::ReportController < MrttApiController
     # query parameters
     site_id = report_params[:site_id]
     organization_id = report_params[:organization_id]
-    public_only = ActiveModel::Type::Boolean.new.cast(report_params[:public_only]) || true
+    public_only = ActiveModel::Type::Boolean.new.cast(report_params[:public_only])
+
+    if public_only.nil?
+      public_only = true
+    end
 
     # prep
     empty_answer = nil
@@ -105,7 +109,7 @@ class V2::ReportController < MrttApiController
 
     sites.each { |site|
       site_row = {}
-      site_id, registration_intervention_answers, monitoring_answers = get_answers_by_site(site.id, public_only = :public_only)
+      site_id, registration_intervention_answers, monitoring_answers = get_answers_by_site(site.id, public_only)
 
       site_row["site_id"] = site.id
       site_row["site_name"] = site.site_name
@@ -176,7 +180,7 @@ class V2::ReportController < MrttApiController
   end
 
   def report_params
-    params.except(:format, :site).permit(:site_id, :organization_id)
+    params.except(:format, :site).permit(:site_id, :organization_id, :public_only)
   end
 
   def to_human_readable(question, answer)


### PR DESCRIPTION
Fixes issue with inability to export private data due to incorrect parsing of `public_only` query parameter

Examples of fixed behaviour:

1. admin user, `public_only = false` 
[sites_report_2023-06-28_17-54-42.xlsx](https://github.com/globalmangrovewatch/gmw-api/files/11898849/sites_report_2023-06-28_17-54-42.xlsx)

2.  admin user, `public_only = true`
[sites_report_2023-06-28_18-02-32.xlsx](https://github.com/globalmangrovewatch/gmw-api/files/11898857/sites_report_2023-06-28_18-02-32.xlsx)

3. non admin user, `public_ony = false` 
[sites_report_2023-06-28_18-03-07.xlsx](https://github.com/globalmangrovewatch/gmw-api/files/11898861/sites_report_2023-06-28_18-03-07.xlsx)

